### PR TITLE
fix: Fixes param name in the README.md for the search example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import os
 
 with Glean(api_token="client-token") as glean:
     search_response = glean.client.search.query(
-        search_request=models.SearchRequest(query="search term")
+        request=models.SearchRequest(query="search term")
     )
     print(search_response)
 


### PR DESCRIPTION
## Summary

As the title suggests.

### Code changes:
* The parameter name in the README.md for the search example was changed from `search_request` to `request`, clarifying the code's intent.
