### PR TITLE
chore: Add missing tools to mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,9 @@
-[settings]
-# forces us to use the version of python defined in .python-version file
-idiomatic_version_file_enable_tools = ["python"]
-
 [tools]
 poetry = "latest"
+
+# matches version in .python-version
+python = "3.9"
+
+# needed by speakeasy mockserver
+go = "1.22"
+


### PR DESCRIPTION
- `go` for mockserver
- `python` to ensure that it gets installed by CI