### PR TITLE
chore: Add rwjblue-glean/speakeasy-helpers to mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,4 +7,5 @@ python = "3.9"
 # needed by speakeasy mockserver
 go = "1.22"
 "aqua:speakeasy-api/speakeasy" = "latest"
+"ubi:rwjblue-glean/speakeasy-helpers" = "latest"
 


### PR DESCRIPTION
[rwjblu7e-glean/speakeasy-helpers](https://github.com/rwjblue-glean/speakeasy-helpers) is just a grab bag of useful helper commands for working in a speakeasy api client repo.

The main subcommand at the moment (that caused me to create it) is:

```bash
speakeasy-helpers reset-tests --operation-id createannouncement
```

This will remove that operationId from `gen.lock` and `test.arazzo.yaml` so that the next `speakeasy run` will regenerate them. I found doing this by hand to be quite tedious.