### PR TITLE
fix: Add 'input' to allowedRedefinedBuiltins

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -34,6 +34,7 @@ python:
   allowedRedefinedBuiltins:
     - id
     - object
+    - input
   asyncMode: both
   authors:
     - Speakeasy


### PR DESCRIPTION
This will ensure that the arguments are `input` not `input_`.

Fixes https://github.com/gleanwork/api-client-python/pull/61