### PR TITLE
Revert "feat: Add a local-debug target (to make for easier debugging)"

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -5,11 +5,6 @@ sources:
         inputs:
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs
         output: .speakeasy/glean-merged-spec.yaml
-    local-debug:
-        inputs:
-            - location: .speakeasy/glean-merged-spec.yaml
-        registry:
-            location: registry.speakeasyapi.dev/glean-el2/sdk/local-debug
 targets:
     glean:
         target: python
@@ -20,15 +15,6 @@ targets:
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples
-            labelOverride:
-                fixedValue: Python (API Client)
-            blocking: false
-        testing:
-            enabled: true
-    local-debug:
-        target: python
-        source: local-debug
-        codeSamples:
             labelOverride:
                 fixedValue: Python (API Client)
             blocking: false


### PR DESCRIPTION
Reverts gleanwork/api-client-python#31

This broke generation, if we want to bring this back we can but we'll need some tweaks to fix the failures we are seeing [in the action](https://github.com/gleanwork/api-client-python/actions/runs/19317671078/job/55252336113):

```
Error: error running workflow: error running speakeasy command: speakeasy run -t all --installationURLs {"glean":"https://github.com/gleanwork/api-client-python.git","local-debug":"https://github.com/gleanwork/api-client-python.git"} --repo-subdirs {"glean":"","local-debug":""} -r https://github.com/gleanwork/api-client-python.git --skip-testing - exit status 1
Error: failed to validate target local-debug: failed to validate target: code samples output must be a yaml file
 - ::error::failed to validate target local-debug: failed to validate target: code samples output must be a yaml file
```