### PR TITLE
fix: speakeasy release links

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,6 +12,7 @@ targets:
         publish:
             pypi:
                 token: $pypi_token
+                packageName: glean-api-client
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples


### PR DESCRIPTION
The GitHub releases point to https://pypi.org/project/glean But the project is actually glean-api-client

Update the package name in speakeasy config to fix this.
