### PR TITLE
fix: Move `multipartArrayFormat` to correct section in `gen.yaml`

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -29,7 +29,6 @@ generation:
     generateTests: true
     generateNewTests: true
     skipResponseBodyAssertions: true
-  multipartArrayFormat: standard
 python:
   version: 0.11.22
   additionalDependencies:
@@ -76,3 +75,4 @@ python:
   responseFormat: flat
   sseFlatResponse: false
   templateVersion: v2
+  multipartArrayFormat: standard


### PR DESCRIPTION
The [docs](https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml#multipartarrayformat) clearly show `multipartArrayFormat` as nested under the "Generation" section, but the latest generation is trying to add it to the language specific section (with the legacy value).