### PR TITLE
feat: add X-Glean headers for experimental features and deprecation testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Remember that each namespace requires its own authentication token type as descr
   * [Custom HTTP Client](#custom-http-client)
   * [Resource Management](#resource-management)
   * [Debugging](#debugging)
+  * [Experimental Features and Deprecation Testing](#experimental-features-and-deprecation-testing)
 * [Development](#development)
   * [Maturity](#maturity)
   * [Contributions](#contributions)
@@ -959,6 +960,62 @@ s = Glean(debug_logger=logging.getLogger("glean.api_client"))
 
 You can also enable a default debug logger by setting an environment variable `GLEAN_DEBUG` to true.
 <!-- End Debugging [debug] -->
+
+## Experimental Features and Deprecation Testing
+
+The SDK provides options to test upcoming API changes before they become the default behavior. This is useful for:
+
+- **Testing experimental features** before they are generally available
+- **Preparing for deprecations** by excluding deprecated endpoints ahead of their removal
+
+### Configuration Options
+
+You can configure these options either via environment variables or SDK constructor options:
+
+#### Using Environment Variables
+
+```python
+import os
+
+# Set environment variables before initializing the SDK
+os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = "2026-10-15"
+os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true"
+
+from glean.api_client import Glean
+
+glean = Glean(
+    api_token=os.environ.get("GLEAN_API_TOKEN", ""),
+    instance=os.environ.get("GLEAN_INSTANCE", ""),
+)
+```
+
+#### Using SDK Constructor Options
+
+```python
+import os
+
+from glean.api_client import Glean
+
+glean = Glean(
+    api_token=os.environ.get("GLEAN_API_TOKEN", ""),
+    instance=os.environ.get("GLEAN_INSTANCE", ""),
+    exclude_deprecated_after="2026-10-15",
+    include_experimental=True,
+)
+```
+
+### Option Reference
+
+| Option | Environment Variable | Type | Description |
+| ------ | -------------------- | ---- | ----------- |
+| `exclude_deprecated_after` | `X_GLEAN_EXCLUDE_DEPRECATED_AFTER` | `str` (date) | Exclude API endpoints that will be deprecated after this date (format: `YYYY-MM-DD`). Use this to test your integration against upcoming deprecations. |
+| `include_experimental` | `X_GLEAN_INCLUDE_EXPERIMENTAL` | `bool` | When `True`, enables experimental API features that are not yet generally available. Use this to preview and test new functionality. |
+
+> [!NOTE]
+> Environment variables take precedence over SDK constructor options when both are set.
+
+> [!WARNING]
+> Experimental features may change or be removed without notice. Do not rely on experimental features in production environments.
 
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 

--- a/src/glean/api_client/_hooks/registration.py
+++ b/src/glean/api_client/_hooks/registration.py
@@ -1,6 +1,7 @@
 from .types import Hooks
 from .multipart_fix_hook import MultipartFileFieldFixHook
 from .agent_file_upload_error_hook import AgentFileUploadErrorHook
+from .x_glean import XGlean
 
 
 # This file is only ever generated once on the first generation and then is free to be modified.
@@ -19,3 +20,6 @@ def init_hooks(hooks: Hooks):
 
     # Register hook to provide helpful error messages for agent file upload issues
     hooks.register_after_error_hook(AgentFileUploadErrorHook())
+
+    # Register hook for X-Glean headers (experimental features and deprecation testing)
+    hooks.register_before_request_hook(XGlean())

--- a/src/glean/api_client/_hooks/x_glean.py
+++ b/src/glean/api_client/_hooks/x_glean.py
@@ -1,0 +1,80 @@
+"""Hook to set X-Glean headers for experimental features and deprecation testing."""
+
+import os
+from typing import Optional, Union
+import httpx
+from glean.api_client._hooks.types import BeforeRequestContext, BeforeRequestHook
+
+
+def _get_first_value(
+    env_value: Optional[str],
+    config_value: Optional[str],
+) -> Optional[str]:
+    """Get the first non-empty value from the provided arguments.
+
+    Environment variables take precedence over SDK constructor options.
+    """
+    if env_value:
+        return env_value
+    if config_value:
+        return config_value
+    return None
+
+
+class XGlean(BeforeRequestHook):
+    """
+    Hook that sets X-Glean headers for experimental features and deprecation testing.
+
+    This hook adds the following headers when configured:
+    - X-Glean-Exclude-Deprecated-After: Excludes API endpoints deprecated after this date
+    - X-Glean-Experimental: Enables experimental API features
+
+    Configuration can be done via environment variables or SDK constructor options.
+    Environment variables take precedence over SDK constructor options.
+    """
+
+    def before_request(
+        self, hook_ctx: BeforeRequestContext, request: httpx.Request
+    ) -> Union[httpx.Request, Exception]:
+        """
+        Add X-Glean headers to the request based on configuration.
+
+        Args:
+            hook_ctx: Context containing SDK configuration
+            request: The HTTP request being made
+
+        Returns:
+            The modified request with X-Glean headers added
+        """
+        # Get deprecated value - env var takes precedence
+        deprecated_value = _get_first_value(
+            os.environ.get("X_GLEAN_EXCLUDE_DEPRECATED_AFTER"),
+            hook_ctx.config.exclude_deprecated_after,
+        )
+
+        # Get experimental value - env var takes precedence
+        config_experimental = (
+            "true" if hook_ctx.config.include_experimental is True else None
+        )
+        experimental_value = _get_first_value(
+            os.environ.get("X_GLEAN_INCLUDE_EXPERIMENTAL"),
+            config_experimental,
+        )
+
+        # Create new headers dict with existing headers
+        new_headers = dict(request.headers)
+
+        if deprecated_value:
+            new_headers["X-Glean-Exclude-Deprecated-After"] = deprecated_value
+
+        if experimental_value:
+            new_headers["X-Glean-Experimental"] = experimental_value
+
+        # Return new request with updated headers
+        return httpx.Request(
+            method=request.method,
+            url=request.url,
+            headers=new_headers,
+            content=request.content,
+            extensions=request.extensions,
+        )

--- a/src/glean/api_client/sdk.py
+++ b/src/glean/api_client/sdk.py
@@ -61,6 +61,8 @@ class Glean(BaseSDK):
         retry_config: OptionalNullable[RetryConfig] = UNSET,
         timeout_ms: Optional[int] = None,
         debug_logger: Optional[Logger] = None,
+        exclude_deprecated_after: Optional[str] = None,
+        include_experimental: Optional[bool] = None,
     ) -> None:
         r"""Instantiates the SDK configuring it with the provided parameters.
 
@@ -73,6 +75,8 @@ class Glean(BaseSDK):
         :param async_client: The Async HTTP client to use for all asynchronous methods
         :param retry_config: The retry configuration to use for all supported methods
         :param timeout_ms: Optional request timeout applied to each operation in milliseconds
+        :param exclude_deprecated_after: Exclude API endpoints deprecated after this date (YYYY-MM-DD)
+        :param include_experimental: When True, enables experimental API features
         """
         client_supplied = True
         if client is None:
@@ -125,6 +129,8 @@ class Glean(BaseSDK):
                 retry_config=retry_config,
                 timeout_ms=timeout_ms,
                 debug_logger=debug_logger,
+                exclude_deprecated_after=exclude_deprecated_after,
+                include_experimental=include_experimental,
             ),
             parent_ref=self,
         )

--- a/src/glean/api_client/sdkconfiguration.py
+++ b/src/glean/api_client/sdkconfiguration.py
@@ -39,6 +39,19 @@ class SDKConfiguration:
     user_agent: str = __user_agent__
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
+    exclude_deprecated_after: Optional[str] = None
+    """
+    Exclude API endpoints that will be deprecated after this date.
+    Use this to test your integration against upcoming deprecations.
+    Format: YYYY-MM-DD (e.g., '2026-10-15')
+
+    More information: https://developers.glean.com/deprecations/overview
+    """
+    include_experimental: Optional[bool] = None
+    """
+    When True, enables experimental API features that are not yet generally available.
+    Use this to preview and test new functionality.
+    """
 
     def get_server_details(self) -> Tuple[str, Dict[str, str]]:
         if self.server_url is not None and self.server_url:

--- a/tests/test_x_glean_hook.py
+++ b/tests/test_x_glean_hook.py
@@ -1,0 +1,243 @@
+"""Tests for the XGlean hook that sets X-Glean headers."""
+
+import os
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from src.glean.api_client._hooks.x_glean import XGlean
+from src.glean.api_client._hooks.types import BeforeRequestContext, HookContext
+from src.glean.api_client.sdkconfiguration import SDKConfiguration
+
+
+def create_mock_request() -> httpx.Request:
+    """Create a mock HTTP request for testing."""
+    return httpx.Request("GET", "https://example.com/api/test")
+
+
+def create_mock_context(
+    exclude_deprecated_after: str = None,
+    include_experimental: bool = None,
+) -> BeforeRequestContext:
+    """Create a mock BeforeRequestContext with the given SDK configuration options."""
+    config = Mock(spec=SDKConfiguration)
+    config.exclude_deprecated_after = exclude_deprecated_after
+    config.include_experimental = include_experimental
+
+    hook_ctx = Mock(spec=HookContext)
+    hook_ctx.config = config
+    hook_ctx.base_url = "https://example.com"
+    hook_ctx.operation_id = "test-operation"
+    hook_ctx.oauth2_scopes = None
+    hook_ctx.security_source = None
+
+    context = BeforeRequestContext(hook_ctx)
+    return context
+
+
+class TestXGleanHook:
+    """Test cases for the XGlean hook."""
+
+    @pytest.fixture(autouse=True)
+    def clear_env_vars(self):
+        """Clear X-Glean environment variables before and after each test."""
+        # Store original values
+        original_deprecated = os.environ.get("X_GLEAN_EXCLUDE_DEPRECATED_AFTER")
+        original_experimental = os.environ.get("X_GLEAN_INCLUDE_EXPERIMENTAL")
+
+        # Clear for test
+        os.environ.pop("X_GLEAN_EXCLUDE_DEPRECATED_AFTER", None)
+        os.environ.pop("X_GLEAN_INCLUDE_EXPERIMENTAL", None)
+
+        yield
+
+        # Restore original values
+        if original_deprecated is not None:
+            os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = original_deprecated
+        else:
+            os.environ.pop("X_GLEAN_EXCLUDE_DEPRECATED_AFTER", None)
+
+        if original_experimental is not None:
+            os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = original_experimental
+        else:
+            os.environ.pop("X_GLEAN_INCLUDE_EXPERIMENTAL", None)
+
+    def test_no_headers_when_neither_options_nor_env_vars_set(self):
+        """Should not set any X-Glean headers when nothing is configured."""
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context()
+
+        result = hook.before_request(context, request)
+
+        assert "X-Glean-Exclude-Deprecated-After" not in result.headers
+        assert "X-Glean-Experimental" not in result.headers
+
+    def test_sets_deprecated_header_from_sdk_option(self):
+        """Should set X-Glean-Exclude-Deprecated-After header from SDK option."""
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(exclude_deprecated_after="2026-10-15")
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2026-10-15"
+
+    def test_sets_experimental_header_when_include_experimental_is_true(self):
+        """Should set X-Glean-Experimental header when includeExperimental is True."""
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(include_experimental=True)
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_no_experimental_header_when_include_experimental_is_false(self):
+        """Should not set X-Glean-Experimental header when includeExperimental is False."""
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(include_experimental=False)
+
+        result = hook.before_request(context, request)
+
+        assert "X-Glean-Experimental" not in result.headers
+
+    def test_sets_both_headers_when_both_options_provided(self):
+        """Should set both headers when both options are provided."""
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(
+            exclude_deprecated_after="2026-10-15",
+            include_experimental=True,
+        )
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2026-10-15"
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_sets_deprecated_header_from_env_var(self):
+        """Should set X-Glean-Exclude-Deprecated-After header from environment variable."""
+        os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = "2027-01-01"
+
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context()
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2027-01-01"
+
+    def test_sets_experimental_header_from_env_var(self):
+        """Should set X-Glean-Experimental header from environment variable."""
+        os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true"
+
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context()
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_sets_both_headers_from_env_vars(self):
+        """Should set both headers from environment variables."""
+        os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = "2027-06-15"
+        os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true"
+
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context()
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2027-06-15"
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_env_var_takes_precedence_for_deprecated(self):
+        """Environment variable should take precedence over SDK option for deprecated."""
+        os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = "2027-12-31"
+
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(exclude_deprecated_after="2026-01-01")
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2027-12-31"
+
+    def test_env_var_takes_precedence_for_experimental(self):
+        """Environment variable should take precedence over SDK option for experimental."""
+        os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true"
+
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(include_experimental=False)
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_env_vars_take_precedence_for_both_headers(self):
+        """Environment variables should take precedence for both headers when all are set."""
+        os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = "2028-01-01"
+        os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true"
+
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(
+            exclude_deprecated_after="2026-06-01",
+            include_experimental=False,
+        )
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2028-01-01"
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_preserves_existing_headers(self):
+        """Should preserve existing headers when adding X-Glean headers."""
+        hook = XGlean()
+        request = httpx.Request(
+            "GET",
+            "https://example.com/api/test",
+            headers={"Authorization": "Bearer token", "Content-Type": "application/json"},
+        )
+        context = create_mock_context(
+            exclude_deprecated_after="2026-10-15",
+            include_experimental=True,
+        )
+
+        result = hook.before_request(context, request)
+
+        assert result.headers.get("Authorization") == "Bearer token"
+        assert result.headers.get("Content-Type") == "application/json"
+        assert result.headers.get("X-Glean-Exclude-Deprecated-After") == "2026-10-15"
+        assert result.headers.get("X-Glean-Experimental") == "true"
+
+    def test_returns_httpx_request_instance(self):
+        """Should return an httpx.Request instance."""
+        hook = XGlean()
+        request = create_mock_request()
+        context = create_mock_context(include_experimental=True)
+
+        result = hook.before_request(context, request)
+
+        assert isinstance(result, httpx.Request)
+
+    def test_preserves_request_method_and_url(self):
+        """Should preserve the original request method and URL."""
+        hook = XGlean()
+        request = httpx.Request("POST", "https://api.example.com/v1/search")
+        context = create_mock_context(include_experimental=True)
+
+        result = hook.before_request(context, request)
+
+        assert result.method == "POST"
+        assert str(result.url) == "https://api.example.com/v1/search"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

- Add `XGlean` beforeRequest hook that sets `X-Glean-Exclude-Deprecated-After` and `X-Glean-Experimental` headers
- Introduce new SDK options `exclude_deprecated_after` and `include_experimental` with corresponding environment variable support
- Add documentation for testing experimental features and deprecation testing

This is the Python equivalent of https://github.com/gleanwork/api-client-typescript/pull/95

## Test plan

- [x] Verify headers are set correctly when using SDK constructor options
- [x] Verify headers are set correctly when using environment variables
- [x] Confirm environment variables take precedence over SDK options
- [x] Ensure no headers are set when neither option is configured

```python
import os
from glean.api_client import Glean

os.environ["X_GLEAN_EXCLUDE_DEPRECATED_AFTER"] = "2027-10-15"
os.environ["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true"

# Test with SDK options
glean = Glean(
    api_token=os.environ.get("GLEAN_API_TOKEN", ""),
    instance=os.environ.get("GLEAN_INSTANCE", ""),
    exclude_deprecated_after="2026-10-15",
    include_experimental=True,
)

result = glean.client.search.query(query="test")
print("Response received:", result)
```