### PR TITLE
fix: make X-Glean hook resilient to SDK regeneration

### DIFF
--- a/src/glean/api_client/_hooks/x_glean.py
+++ b/src/glean/api_client/_hooks/x_glean.py
@@ -49,12 +49,12 @@ class XGlean(BeforeRequestHook):
         # Get deprecated value - env var takes precedence
         deprecated_value = _get_first_value(
             os.environ.get("X_GLEAN_EXCLUDE_DEPRECATED_AFTER"),
-            hook_ctx.config.exclude_deprecated_after,
+            getattr(hook_ctx.config, "exclude_deprecated_after", None),
         )
 
         # Get experimental value - env var takes precedence
         config_experimental = (
-            "true" if hook_ctx.config.include_experimental is True else None
+            "true" if getattr(hook_ctx.config, "include_experimental", None) is True else None
         )
         experimental_value = _get_first_value(
             os.environ.get("X_GLEAN_INCLUDE_EXPERIMENTAL"),


### PR DESCRIPTION
## Summary

- Use `getattr()` with defaults instead of direct attribute access for `exclude_deprecated_after` and `include_experimental` config fields
- Fixes mypy errors that occur after Speakeasy regenerates `sdkconfiguration.py`

## Background

PR #106 added custom fields to `sdkconfiguration.py` for X-Glean header support. However, Speakeasy regenerates this file daily, removing the custom fields. The hook (`x_glean.py`) survives regeneration but then references non-existent attributes, causing mypy failures:

```
src/glean/api_client/_hooks/x_glean.py:52: error: "SDKConfiguration" has no attribute "exclude_deprecated_after"
src/glean/api_client/_hooks/x_glean.py:57: error: "SDKConfiguration" has no attribute "include_experimental"
```

This has been breaking the Generate CI workflow since Jan 27th.

## Solution

Replace direct attribute access with `getattr()` calls that return `None` when the attribute doesn't exist:

```python
# Before
hook_ctx.config.exclude_deprecated_after
hook_ctx.config.include_experimental

# After  
getattr(hook_ctx.config, "exclude_deprecated_after", None)
getattr(hook_ctx.config, "include_experimental", None)
```

## Verification

- ✅ Ran actual `speakeasy run` which regenerated `sdkconfiguration.py` without custom attributes
- ✅ mypy passes after regeneration
- ✅ All 14 hook tests pass after regeneration
- ✅ Environment variables continue to work (they take precedence anyway)

## Test plan

- [x] Run mypy: `poetry run python -m mypy src/glean/api_client`
- [x] Run hook tests: `poetry run pytest tests/test_x_glean_hook.py -v`
- [x] Run actual Speakeasy generation and verify mypy still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)